### PR TITLE
NoAlways

### DIFF
--- a/.github/workflows/elm-checks.yaml
+++ b/.github/workflows/elm-checks.yaml
@@ -168,5 +168,6 @@ jobs:
         run: echo ::add-path::$(yarn bin)
       - name: Publish package
         uses: dillonkearns/elm-publish-action@1.0.1
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "concat",
+        "tuple"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Provides an [`elm-review`](https://package.elm-lang.org/packages/jfmengels/elm-r
 ## Example configuration
 
 ```elm
-module ReviewConfig exposing (config)
-
 import Review.Rule exposing (Rule)
 import NoAlways
 

--- a/elm.json
+++ b/elm.json
@@ -10,7 +10,6 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "elm/parser": "1.1.0 <= v < 2.0.0",
         "jfmengels/elm-review": "2.0.0 <= v < 3.0.0",
         "stil4m/elm-syntax": "7.1.1 <= v < 8.0.0"
     },

--- a/review/elm.json
+++ b/review/elm.json
@@ -1,0 +1,40 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/project-metadata-utils": "1.0.1",
+            "jfmengels/elm-review": "2.0.1",
+            "jfmengels/review-common": "1.0.0",
+            "jfmengels/review-debug": "2.0.1",
+            "jfmengels/review-unused": "2.0.2",
+            "sparksp/elm-review-camelcase": "1.0.1",
+            "stil4m/elm-syntax": "7.1.1"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "elm-community/json-extra": "4.2.0",
+            "elm-community/list-extra": "8.2.4",
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-hex": "1.0.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
+            "stil4m/structured-writer": "1.0.2"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {}
+    }
+}

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -1,0 +1,41 @@
+module ReviewConfig exposing (config)
+
+{-| Do not rename the ReviewConfig module or the config function, because
+`elm-review` will look for these.
+
+To add packages that contain rules, add them to this review project using
+
+    `elm install author/packagename`
+
+when inside the directory containing this file.
+
+-}
+
+import NoDebug.Log
+import NoDebug.TodoOrToString
+import NoExposingEverything
+import NoImportingEverything
+import NoMissingTypeAnnotation
+import NoUnused.CustomTypeConstructors
+import NoUnused.Dependencies
+import NoUnused.Exports
+import NoUnused.Modules
+import NoUnused.Variables
+import UseCamelCase
+import Review.Rule exposing (Rule)
+
+
+config : List Rule
+config =
+    [ NoDebug.Log.rule
+    , NoDebug.TodoOrToString.rule
+    , NoExposingEverything.rule
+    , NoImportingEverything.rule []
+    , NoMissingTypeAnnotation.rule
+    , NoUnused.CustomTypeConstructors.rule []
+    , NoUnused.Dependencies.rule
+    , NoUnused.Exports.rule
+    , NoUnused.Modules.rule
+    , NoUnused.Variables.rule
+    , UseCamelCase.rule UseCamelCase.default
+    ]

--- a/src/NoAlways/Context.elm
+++ b/src/NoAlways/Context.elm
@@ -1,0 +1,59 @@
+module NoAlways.Context exposing
+    ( initial
+    , needBrackets, clearNeedBrackets, resetNeedBrackets
+    , Module
+    )
+
+{-|
+
+@docs Context, initial
+
+
+## Brackets
+
+@docs needBrackets, clearNeedBrackets, resetNeedBrackets
+
+-}
+
+
+{-| Module Context for NoAlways
+-}
+type Module
+    = Brackets Bool
+
+
+{-| New Module Context
+-}
+initial : Module
+initial =
+    Brackets True
+
+
+{-| If I turn the next expression into a lambda would I need to wrap it with brackets?
+
+    -- Brackets needed
+    foo = always "bar"
+    -> foo = (\_ -> "bar")
+
+    -- Brackets not needed
+    foo = bar (always "bar")
+    -> foo = bar (\_ -> "bar")
+
+-}
+needBrackets : Module -> Bool
+needBrackets (Brackets brackets) =
+    brackets
+
+
+{-| Mark that the next expression **does not** want brackets.
+-}
+clearNeedBrackets : Module -> Module
+clearNeedBrackets _ =
+    Brackets False
+
+
+{-| Mark that the next expression **does want** brackets.
+-}
+resetNeedBrackets : Module -> Module
+resetNeedBrackets _ =
+    Brackets True


### PR DESCRIPTION
# NoAlways

Use anonymous function `\_ ->` over `always`.

```elm
config : List Rule
config =
    [ NoAlways.rule
    ]
```

It's more concise, more recognisable as a function, and makes it easier to change your mind later and name the argument.


## Failure

```elm
-- Don't do this --
List.map (always 0) [ 1, 2, 3, 4 ]
```

## Success

```elm
-- Instead do this --
List.map (\_ -> 0) [ 1, 2, 3, 4 ]
```
