### PR TITLE
Add a caution about heavy computation

### DIFF
--- a/src/NoAlways.elm
+++ b/src/NoAlways.elm
@@ -16,16 +16,24 @@ import Review.Fix as Fix exposing (Fix)
 import Review.Rule as Rule exposing (Error, Rule)
 
 
-{-| Forbid the use of `always`.
+{-| Forbid the use of [`always`][always].
 
     config : List Rule
     config =
         [ NoAlways.rule
         ]
 
-Use anonymous function `\_ ->` over `always`.
+Use an [anonymous function] `\_ ->` instead of `always`.
 
 It's more concise, more recognizable as a function, and makes it easier to change your mind later and name the argument.
+
+[always]: https://package.elm-lang.org/packages/elm/core/latest/Basics#always
+[anonymous function]: https://elm-lang.org/docs/syntax#functions
+
+
+## When (not) to use this rule
+
+If you are in a team then other members may have strong opinions about `always` - make sure that everyone is on board before you decide to adopt this rule.
 
 
 ## Failure
@@ -33,11 +41,31 @@ It's more concise, more recognizable as a function, and makes it easier to chang
     -- Don't do this --
     List.map (always 0) [ 1, 2, 3, 4 ]
 
-
-## Success
-
     -- Instead do this --
     List.map (\_ -> 0) [ 1, 2, 3, 4 ]
+
+
+## Caution: Heavy Computation
+
+If the value you always want is the result of some heavy computation then you will not want that within an anonymous function as the work will be done every time. Instead, do the calculation in a nearby [`let..in`][let-expression] block first.
+
+    -- Don't do this --
+    List.map (always (heavyComputation arg1 arg2)) [ 1, 2, 3, 4 ]
+
+    -- Don't do this either --
+    List.map (\_ -> heavyComputation arg1 arg2) [ 1, 2, 3, 4 ]
+
+    -- Instead do this --
+    let
+        heavyComputationResult =
+            heavyComputation arg1 arg2
+    in
+    List.map (\_ -> heavyComputationResult) [ 1, 2, 3, 4 ]
+
+    -- This works too (but is less readable) --
+    List.map ((\value _ -> value) (heavyComputation arg1 arg2)) [ 1, 2, 3, 4 ]
+
+[let-expression]: https://elm-lang.org/docs/syntax#let-expressions
 
 -}
 rule : Rule

--- a/tests/NoAlwaysTests.elm
+++ b/tests/NoAlwaysTests.elm
@@ -100,6 +100,22 @@ foo =
     ( "foo", (\\_ -> "bar") )
 """
                         ]
+        , test "always pipe right" <|
+            \_ ->
+                """
+module Foo exposing (foo)
+foo = "foo" |> always
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
+        , test "always pipe left" <|
+            \_ ->
+                """
+module Foo exposing (foo)
+foo = always <| heavyComputation "foo"
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
         ]
 
 


### PR DESCRIPTION
## Caution: Heavy Computation

If the value you always want is the result of some heavy computation then you will not want that within an anonymous function as the work will be done every time. Instead, do the calculation in a nearby [`let..in`][let-expression] block first.

```elm
-- Don't do this --
List.map (always (heavyComputation arg1 arg2)) [ 1, 2, 3, 4 ]

-- Don't do this either --
List.map (\_ -> heavyComputation arg1 arg2) [ 1, 2, 3, 4 ]

-- Instead do this --
let
    heavyComputationResult =
        heavyComputation arg1 arg2
in
List.map (\_ -> heavyComputationResult) [ 1, 2, 3, 4 ]

-- This works too (but is less readable) --
List.map ((\value _ -> value) (heavyComputation arg1 arg2)) [ 1, 2, 3, 4 ]
```

[let-expression]: https://elm-lang.org/docs/syntax#let-expressions
