### PR TITLE
Warn about possible heavy computation

### DIFF
--- a/src/NoAlways.elm
+++ b/src/NoAlways.elm
@@ -105,6 +105,15 @@ containsFunctionOrValue (Node _ expression) =
                 Nothing ->
                     False
 
+        Expression.IfBlock _ _ _ ->
+            True
+
+        Expression.CaseExpression _ ->
+            True
+
+        Expression.LetExpression _ ->
+            True
+
         Expression.ParenthesizedExpression next ->
             containsFunctionOrValue next
 
@@ -130,6 +139,9 @@ containsFunctionOrValue (Node _ expression) =
             False
 
         Expression.Literal _ ->
+            False
+
+        Expression.CharLiteral _ ->
             False
 
         Expression.Hex _ ->

--- a/src/NoAlways.elm
+++ b/src/NoAlways.elm
@@ -85,91 +85,91 @@ expressionVisitor (Node range node) =
 
 alwaysExpressionError : { always : Range, application : Range } -> Node Expression -> Error {}
 alwaysExpressionError ranges expression =
-    if containsFunctionOrValue expression then
-        errorWithWarning ranges.always
-
-    else
+    if isConstantExpression expression then
         errorWithFix ranges.always (fixAlways ranges expression)
 
+    else
+        errorWithWarning ranges.always
 
-containsFunctionOrValue : Node Expression -> Bool
-containsFunctionOrValue (Node _ expression) =
+
+isConstantExpression : Node Expression -> Bool
+isConstantExpression (Node _ expression) =
     case expression of
+        Expression.UnitExpr ->
+            True
+
+        Expression.Floatable _ ->
+            True
+
+        Expression.Integer _ ->
+            True
+
+        Expression.Literal _ ->
+            True
+
+        Expression.CharLiteral _ ->
+            True
+
+        Expression.Hex _ ->
+            True
+
+        Expression.RecordAccess _ _ ->
+            True
+
+        Expression.RecordAccessFunction _ ->
+            True
+
+        Expression.LambdaExpression _ ->
+            True
+
+        Expression.PrefixOperator _ ->
+            True
+
+        Expression.Operator _ ->
+            True
+
         Expression.FunctionOrValue _ name ->
             case String.uncons name of
                 Just ( start, _ ) ->
-                    Char.isLower start
+                    Char.isUpper start
 
                 Nothing ->
-                    False
-
-        Expression.IfBlock _ _ _ ->
-            True
-
-        Expression.CaseExpression _ ->
-            True
-
-        Expression.LetExpression _ ->
-            True
-
-        Expression.RecordUpdateExpression _ _ ->
-            True
-
-        Expression.GLSLExpression _ ->
-            True
-
-        Expression.ParenthesizedExpression next ->
-            containsFunctionOrValue next
-
-        Expression.Application list ->
-            List.any containsFunctionOrValue list
-
-        Expression.TupledExpression list ->
-            List.any containsFunctionOrValue list
-
-        Expression.ListExpr list ->
-            List.any containsFunctionOrValue list
-
-        Expression.OperatorApplication _ _ left right ->
-            List.any containsFunctionOrValue [ left, right ]
-
-        Expression.RecordExpr list ->
-            List.any (Node.value >> Tuple.second >> containsFunctionOrValue) list
-
-        Expression.UnitExpr ->
-            False
-
-        Expression.Floatable _ ->
-            False
-
-        Expression.Integer _ ->
-            False
-
-        Expression.Literal _ ->
-            False
-
-        Expression.CharLiteral _ ->
-            False
-
-        Expression.Hex _ ->
-            False
-
-        Expression.RecordAccess _ _ ->
-            False
-
-        Expression.RecordAccessFunction _ ->
-            False
+                    True
 
         Expression.Negation next ->
-            containsFunctionOrValue next
+            isConstantExpression next
 
-        Expression.LambdaExpression _ ->
+        Expression.ParenthesizedExpression next ->
+            isConstantExpression next
+
+        Expression.Application list ->
+            List.all isConstantExpression list
+
+        Expression.TupledExpression list ->
+            List.all isConstantExpression list
+
+        Expression.ListExpr list ->
+            List.all isConstantExpression list
+
+        Expression.OperatorApplication _ _ left right ->
+            List.all isConstantExpression [ left, right ]
+
+        Expression.RecordExpr list ->
+            List.all (Node.value >> Tuple.second >> isConstantExpression) list
+
+        Expression.IfBlock _ _ _ ->
             False
 
-        Expression.PrefixOperator _ ->
+        Expression.CaseExpression _ ->
             False
 
-        Expression.Operator _ ->
+        Expression.LetExpression _ ->
+            False
+
+        Expression.RecordUpdateExpression _ _ ->
+            False
+
+        Expression.GLSLExpression _ ->
             False
 
 

--- a/tests/Tests/NoAlways.elm
+++ b/tests/Tests/NoAlways.elm
@@ -279,6 +279,21 @@ module Foo exposing (foo)
 foo = (\\_ -> "foo")
 """
                     ]
+    , test "always Char" <|
+        \() ->
+            """
+module Foo exposing (foo)
+foo = always 'a'
+"""
+                |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ alwaysError
+                        |> Review.Test.whenFixed
+                            """
+module Foo exposing (foo)
+foo = (\\_ -> 'a')
+"""
+                    ]
     , test "always Tuple" <|
         \() ->
             """
@@ -385,6 +400,64 @@ foo = always ( heavyComputation, 1.0 )
             """
 module Foo exposing (foo)
 foo = always -bar
+"""
+                |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ alwaysErrorWithWarning
+                    ]
+    , test "always operator functions includes extra warning" <|
+        \() ->
+            """
+module Foo exposing (foo)
+foo = always (bish + bosh)
+"""
+                |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ alwaysErrorWithWarning
+                    ]
+    , test "always if includes extra warning" <|
+        \() ->
+            """
+module Foo exposing (foo)
+foo =
+    always
+        (if bish then
+            bosh
+
+         else
+            bash
+        )
+"""
+                |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ alwaysErrorWithWarning
+                    ]
+    , test "always case includes extra warning" <|
+        \() ->
+            """
+module Foo exposing (foo)
+foo =
+    always
+        (case bar of
+            Bish -> bish
+            Bosh -> bosh
+        )
+"""
+                |> Review.Test.run rule
+                |> Review.Test.expectErrors
+                    [ alwaysErrorWithWarning
+                    ]
+    , test "always with let includes extra warning" <|
+        \() ->
+            """
+module Foo exposing (foo)
+foo =
+    always
+        (let
+             bar = heavyComputation
+         in
+         bar
+        )
 """
                 |> Review.Test.run rule
                 |> Review.Test.expectErrors


### PR DESCRIPTION
When the `always` is a constant then provide a fix, otherwise we do not offer a fix and include an extra warning about possible heavy computation in lambda functions. This gives the user an opportunity to review the code replacing the always.

Constants:
  * Units (`()`)
  * Numbers (`3.1415`, `365`, `0xFF`, `-5`)
  * Literals (`"Hello"`, `'I'`)
  * Record Access (`model.user`)
  * Functions (including lambdas, prefix operators and record access functions)
